### PR TITLE
More Makefile changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ venv/
 __pycache__/
 .mypy_cache/
 
+**/.buildmarker
+
 instance/
 
 .pytest_cache/

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,41 @@
-ACTIVATE_VENV := . venv/bin/activate
+MAKEFLAGS += --jobs=4
 
+VENV_RUN := . venv/bin/activate &&
+RMRF := rm -Rf
+
+MARKER_FILENAME := .buildmarker
+FRONTEND_MARKER := frontend/$(MARKER_FILENAME)
+
+# Default target:
+.PHONY: dev_server
+dev_server: frontend
+	@$(VENV_RUN) FLASK_APP=whathappened FLASK_ENV=development flask run
+
+# Install Python dependencies:
 .PHONY: setup_dependencies
-setup_dependencies: venv/marker
+setup_dependencies: venv/$(MARKER_FILENAME)
 
-venv/marker: requirements.txt
-	python3 -m venv venv
-	$(ACTIVATE_VENV) && pip3 install -r requirements.txt
-	touch venv/marker
+venv/$(MARKER_FILENAME): requirements.txt
+	@python3 -m venv venv
+	@$(VENV_RUN) pip3 install -r requirements.txt
+	@touch $@
 
+# Initialise database:
 .PHONY: setup
 setup: setup_dependencies
-	$(ACTIVATE_VENV) &&	flask db upgrade
+	@$(VENV_RUN) flask db upgrade
 
-dev:
-	$(ACTIVATE_VENV) &&	FLASK_APP=whathappened FLASK_ENV=development flask run
+# Install npm dependencies:
+$(FRONTEND_MARKER): frontend/package.json
+	@cd frontend && npm install && cd ..
+	@touch $@
+
+# Build the Flask frontend:
+.PHONY: frontend
+frontend: $(FRONTEND_MARKER) setup
+	@$(VENV_RUN) flask main build
+
+# Clean out build artefacts:
+clean:
+	$(RMRF) venv
+	$(RMRF) $(FRONTEND_MARKER)

--- a/README.md
+++ b/README.md
@@ -34,36 +34,46 @@ Come back later.
 
 ## Development and testing
 
-To get started, clone the project with git. Now run:
+To get started, clone the project with git.
 
-```
-$ make setup
-```
+### Prerequisites
 
-This will have created a virtual environment for you. Feel free to activate it
-if you want, but all the make targets will do it for you if you only use those.
+* `make` (probably the GNU variety)
+* `node` and `npm`
+* Python 3
 
-You can run the flask app with:
+### Setup and build
 
-```
-$ make dev
-```
+The following command sets up dependencies for you, and builds and runs the
+Flask app. See the terminal output for the URL where it can be reached.
 
-See the output for the URL where it can be reached.
+`$ make`
 
-### Other shells
+### Notes
 
-If you are using a different shell than `bash` or `zsh`, e.g. `fish`, the
-activation might not work like that, but you can then do
+#### How to only run the setup part
+
+`$ make setup`
+
+This creates a Python virtual environment for you. All the make targets will
+activate it as needed, but feel free to activate it in your shell if you want or
+need to:
+
+`$ . venv/bin/activate`
+
+or if you're running Fish:
 
 `$ . venv/bin/activate.fish`
 
+
+#### Cleaning
+
+`$ make clean`
+
+will clean out the build artefacts.
+
 ### Troubleshooting
 
-### No stylesheet
+#### No stylesheet
 
 You probably need to install sass.
-
-### No javascript
-
-You need to have typescript installed.

--- a/README.md
+++ b/README.md
@@ -71,9 +71,3 @@ or if you're running Fish:
 `$ make clean`
 
 will clean out the build artefacts.
-
-### Troubleshooting
-
-#### No stylesheet
-
-You probably need to install sass.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -695,6 +695,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2296,7 +2297,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -3576,6 +3578,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",


### PR DESCRIPTION
### Update frontend/package-lock.json .

### Add frontend building to Makefile

Build also the frontend code from a make target.

Set up dependency management so that everything can be setup and run by
just executing one Make target, which is also the default target.

Change ACTIVATE_VENV to VENV_RUN and include the `&&` for better
ergonomics.

Set build parallelism to 4 (hardcoded for now).

Also:

* Update README.
* Exclude build marker files in .gitignore.

### Remove sass troubleshooting from README

Remove the paragraph on sass troubleshooting from the README, since sass
processing is handled by the Flask bundler.
